### PR TITLE
Removes the file path from the file object

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,14 @@ documentation = "http://dl.ahorn.me/rust-doc/escposify/escposify/"
 license = "MIT"
 authors = ["Qian Linfeng <thewawar@gmail.com>"]
 
+[features]
+qrcode = [qrcode = "0.3"]
 
 [dependencies]
 encoding = "0.2"
 byteorder = "1.0"
 image = "0.13"
-qrcode = "0.3"
+
 
 [dev-dependencies]
 tempfile = "2.1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,10 @@ authors = ["Qian Linfeng <thewawar@gmail.com>"]
 
 
 [dependencies]
-encoding = "0.2.32"
-byteorder = "0.5.1"
-image = "0.12"
-qrcode = "0.1.7"
+encoding = "0.2"
+byteorder = "1.0"
+image = "0.13"
+qrcode = "0.3"
 
 [dev-dependencies]
 tempfile = "2.1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "escposify"
-version = "0.1.4"
+version = "0.2.0"
 description = "A ESC/POS driver for Rust"
 readme = "README.md"
 keywords = ["ESC", "POS", "printer", "driver"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,14 @@ license = "MIT"
 authors = ["Qian Linfeng <thewawar@gmail.com>"]
 
 [features]
-qrcode = [qrcode = "0.3"]
+qrcode_builder = ["qrcode"]
 
 [dependencies]
 encoding = "0.2"
 byteorder = "1.0"
-image = "0.13"
+image = "0.14"
 
+qrcode =  { version = "0.3", optional = true }
 
 [dev-dependencies]
 tempfile = "2.1.3"

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -15,9 +15,8 @@ fn main() {
     let tempf = NamedTempFileOptions::new()
         .create()
         .unwrap();
-    let temp_path = tempf.path().to_str().unwrap().to_owned();
 
-    let file = File::from(temp_path.as_str(), tempf);
+    let file = File::from(tempf);
     let mut printer = Printer::new(file, None, None);
 
     let img = ImageBuffer::from_fn(512, 512, |x, _| {

--- a/examples/raster.rs
+++ b/examples/raster.rs
@@ -15,9 +15,8 @@ fn main() {
     let tempf = NamedTempFileOptions::new()
         .create()
         .unwrap();
-    let temp_path = tempf.path().to_str().unwrap().to_owned();
 
-    let file = File::from(temp_path.as_str(), tempf);
+    let file = File::from(tempf);
     let mut printer = Printer::new(file, None, None);
 
     let img = ImageBuffer::from_fn(512, 512, |x, _| {

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -10,9 +10,8 @@ fn main() {
     let tempf = NamedTempFileOptions::new()
         .create()
         .unwrap();
-    let temp_path = tempf.path().to_str().unwrap().to_owned();
 
-    let file = File::from(temp_path.as_str(), tempf);
+    let file = File::from(tempf);
     let mut printer = Printer::new(file, None, None);
 
     let _ = printer

--- a/src/device.rs
+++ b/src/device.rs
@@ -39,7 +39,6 @@ impl io::Write for Network {
 
 #[derive(Debug)]
 pub struct File<W> {
-    _path: String,
     fobj: W
 }
 
@@ -50,11 +49,11 @@ impl <W: io::Write> File<W> {
             .create(true)
             .open(&path)
             .unwrap();
-        File{_path: path.to_string(), fobj: fobj}
+        File{fobj: fobj}
     }
 
-    pub fn from(path: &str, fobj: W) -> File<W>{
-        File{_path: path.to_string(), fobj: fobj}
+    pub fn from(fobj: W) -> File<W>{
+        File{fobj: fobj}
     }
 }
 

--- a/src/img.rs
+++ b/src/img.rs
@@ -1,10 +1,9 @@
 
 use std::path;
 use std::iter::Iterator;
-use qrcode::QrCode;
 
 use image;
-use image::{ImageBuffer, DynamicImage, GenericImage};
+use image::{DynamicImage, GenericImage};
 
 
 pub struct Image {
@@ -33,7 +32,10 @@ impl Image {
         }
     }
 
+    #[cfg(feature="qrcode")]
     pub fn from_qr(code: &str, width: u32) -> Image {
+        use qrcode::QrCode;
+        use image::ImageBuffer;
         let code = QrCode::new(code.as_bytes()).unwrap();
         let code_width = code.width() as u32;
         let point_width = width / (code_width + 2);

--- a/src/img.rs
+++ b/src/img.rs
@@ -32,7 +32,7 @@ impl Image {
         }
     }
 
-    #[cfg(feature="qrcode")]
+    #[cfg(feature="qrcode_builder")]
     pub fn from_qr(code: &str, width: u32) -> Image {
         use qrcode::QrCode;
         use image::ImageBuffer;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 extern crate encoding;
 extern crate byteorder;
 extern crate image;
+
+#[cfg(feature="qrcode_builder")]
 extern crate qrcode;
 
 pub mod consts;

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -237,10 +237,12 @@ impl<W: io::Write> Printer<W> {
         self
     }
 
+    #[cfg(feature="qrcode")]
     pub fn qrimage(&mut self) -> &mut Printer<W> {
         self
     }
 
+    #[cfg(feature="qrcode")]
     pub fn qrcode(&mut self,
                   code: &str,
                   version: Option<i32>,

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -12,9 +12,8 @@ fn simple() {
     let tempf = NamedTempFileOptions::new()
         .create()
         .unwrap();
-    let temp_path = tempf.path().to_str().unwrap().to_owned();
 
-    let file = File::from(temp_path.as_str(), tempf);
+    let file = File::from(tempf);
     let mut printer = Printer::new(file, None, None);
 
     let _ = printer


### PR DESCRIPTION
The filepath serves no purpose in the code so it has been removed. This
makes it possible to use tempfile() rather than a pathed one.

Bumps to 0.2 as this is a breaking change