### PR TITLE
Report IO result for each method call on Printer

### DIFF
--- a/src/printer.rs
+++ b/src/printer.rs
@@ -1,34 +1,28 @@
-
-use std::iter;
-use std::io::{Write};
 use std::io;
+use std::io::Write;
+use std::iter;
 
-use encoding::types::{EncodingRef, EncoderTrap};
-use encoding::all::{UTF_8};
 use byteorder::{LittleEndian, WriteBytesExt};
+use encoding::all::UTF_8;
+use encoding::types::{EncoderTrap, EncodingRef};
 
 use consts;
-use img::{Image};
-
+use img::Image;
 
 pub struct Printer<W: io::Write> {
     writer: io::BufWriter<W>,
     codec: EncodingRef,
-    trap: EncoderTrap
+    trap: EncoderTrap,
 }
 
-
 impl<W: io::Write> Printer<W> {
-    pub fn new(writer: W,
-               codec: Option<EncodingRef>,
-               trap: Option<EncoderTrap>) -> Printer<W> {
-        Printer{
+    pub fn new(writer: W, codec: Option<EncodingRef>, trap: Option<EncoderTrap>) -> Printer<W> {
+        Printer {
             writer: io::BufWriter::new(writer),
             codec: codec.unwrap_or(UTF_8 as EncodingRef),
-            trap: trap.unwrap_or(EncoderTrap::Replace)
+            trap: trap.unwrap_or(EncoderTrap::Replace),
         }
     }
-
 
     fn encode(&mut self, content: &str) -> Vec<u8> {
         self.codec.encode(content, self.trap).unwrap()
@@ -39,7 +33,7 @@ impl<W: io::Write> Printer<W> {
     }
 
     pub fn write_u8(&mut self, n: u8) -> io::Result<usize> {
-        self.write(vec!(n).as_slice())
+        self.write(vec![n].as_slice())
     }
 
     fn write_u16le(&mut self, n: u16) -> io::Result<usize> {
@@ -48,63 +42,55 @@ impl<W: io::Write> Printer<W> {
         self.write(wtr.as_slice())
     }
 
-
     pub fn flush(&mut self) -> io::Result<()> {
         self.writer.flush()
     }
 
-    pub fn hwinit(&mut self) -> &mut Printer<W> {
-        let _ = self.write(consts::HW_INIT);
-        self
+    pub fn hwinit(&mut self) -> io::Result<usize> {
+        self.write(consts::HW_INIT)
     }
 
-    pub fn hwselect(&mut self) -> &mut Printer<W> {
-        let _ = self.write(consts::HW_SELECT);
-        self
+    pub fn hwselect(&mut self) -> io::Result<usize> {
+        self.write(consts::HW_SELECT)
     }
 
-    pub fn hwreset(&mut self) -> &mut Printer<W> {
-        let _ = self.write(consts::HW_RESET);
-        self
+    pub fn hwreset(&mut self) -> io::Result<usize> {
+        self.write(consts::HW_RESET)
     }
 
-    pub fn print(&mut self, content: &str) -> &mut Printer<W> {
+    pub fn print(&mut self, content: &str) -> io::Result<usize> {
         // let rv = self.encode(content);
         let rv = self.encode(content);
-        let _ = self.write(rv.as_slice());
-        self
+        self.write(rv.as_slice())
     }
 
-    pub fn println(&mut self, content: &str) -> &mut Printer<W> {
-        self.print(format!("{}{}", content, consts::EOL).as_ref());
-        self
+    pub fn println(&mut self, content: &str) -> io::Result<usize> {
+        self.print(format!("{}{}", content, consts::EOL).as_ref())
     }
 
-    pub fn text(&mut self, content: &str) -> &mut Printer<W> {
-        self.println(content);
-        self
+    pub fn text(&mut self, content: &str) -> io::Result<usize> {
+        self.println(content)
     }
 
-    pub fn line_space(&mut self, n: i32) -> &mut Printer<W> {
+    pub fn line_space(&mut self, n: i32) -> io::Result<usize> {
         if n >= 0 {
-            let _ = self.write(consts::LS_SET);
-            let _ = self.write_u8(n as u8);
+            Ok(self.write(consts::LS_SET)? + self.write_u8(n as u8)?)
         } else {
-            let _ = self.write(consts::LS_DEFAULT);
+            self.write(consts::LS_DEFAULT)
         }
-        self
     }
 
-    pub fn feed(&mut self, n: usize) -> &mut Printer<W> {
+    pub fn feed(&mut self, n: usize) -> io::Result<usize> {
         let n = if n < 1 { 1 } else { n };
-        let _ = self.write(iter::repeat(consts::EOL)
-                           .take(n)
-                           .collect::<String>()
-                           .as_ref());
-        self
+        self.write(
+            iter::repeat(consts::EOL)
+                .take(n)
+                .collect::<String>()
+                .as_ref(),
+        )
     }
 
-    pub fn control(&mut self, ctrl: &str) -> &mut Printer<W> {
+    pub fn control(&mut self, ctrl: &str) -> io::Result<usize> {
         let ctrl_upper = ctrl.to_uppercase();
         let ctrl_value = match ctrl_upper.as_ref() {
             "LF" => consts::CTL_LF,
@@ -112,100 +98,83 @@ impl<W: io::Write> Printer<W> {
             "CR" => consts::CTL_CR,
             "HT" => consts::CTL_HT,
             "VT" => consts::CTL_VT,
-            _ => panic!("Invalid control action: {}", ctrl)
+            _ => panic!("Invalid control action: {}", ctrl),
         };
-        let _ = self.write(ctrl_value);
-        self
+        self.write(ctrl_value)
     }
 
-    pub fn align(&mut self, alignment: &str) -> &mut Printer<W> {
+    pub fn align(&mut self, alignment: &str) -> io::Result<usize> {
         let align_upper = alignment.to_uppercase();
         let align_value = match align_upper.as_ref() {
             "LT" => consts::TXT_ALIGN_LT,
             "CT" => consts::TXT_ALIGN_CT,
             "RT" => consts::TXT_ALIGN_RT,
-            _ => panic!("Invalid alignment: {}", alignment)
+            _ => panic!("Invalid alignment: {}", alignment),
         };
-        let _ = self.write(align_value);
-        self
+        self.write(align_value)
     }
 
-    pub fn font(&mut self, family: &str) -> &mut Printer<W> {
+    pub fn font(&mut self, family: &str) -> io::Result<usize> {
         let family_upper = family.to_uppercase();
         let family_value = match family_upper.as_ref() {
             "A" => consts::TXT_FONT_A,
             "B" => consts::TXT_FONT_B,
             "C" => consts::TXT_FONT_C,
-            _ => panic!("Invalid font family: {}", family)
+            _ => panic!("Invalid font family: {}", family),
         };
-        let _ = self.write(family_value);
-        self
+        self.write(family_value)
     }
 
-    pub fn style(&mut self, kind: &str) -> &mut Printer<W> {
+    pub fn style(&mut self, kind: &str) -> io::Result<usize> {
         let kind_upper = kind.to_uppercase();
         match kind_upper.as_ref() {
-            "B" => {
-                let _ = self.write(consts::TXT_UNDERL_OFF);
-                let _ = self.write(consts::TXT_BOLD_ON);
-            }
-            "U" => {
-                let _ = self.write(consts::TXT_BOLD_OFF);
-                let _ = self.write(consts::TXT_UNDERL_ON);
-            }
-            "U2" => {
-                let _ = self.write(consts::TXT_BOLD_OFF);
-                let _ = self.write(consts::TXT_UNDERL2_ON);
-            }
-            "BU" => {
-                let _ = self.write(consts::TXT_BOLD_ON);
-                let _ = self.write(consts::TXT_UNDERL_ON);
-            }
-            "BU2" => {
-                let _ = self.write(consts::TXT_BOLD_ON);
-                let _ = self.write(consts::TXT_UNDERL2_ON);
-            }
+            "B" => Ok(self.write(consts::TXT_UNDERL_OFF)? + self.write(consts::TXT_BOLD_ON)?),
+            "U" => Ok(self.write(consts::TXT_BOLD_OFF)? + self.write(consts::TXT_UNDERL_ON)?),
+            "U2" => Ok(self.write(consts::TXT_BOLD_OFF)? + self.write(consts::TXT_UNDERL2_ON)?),
+            "BU" => Ok(self.write(consts::TXT_BOLD_ON)? + self.write(consts::TXT_UNDERL_ON)?),
+            "BU2" => Ok(self.write(consts::TXT_BOLD_ON)? + self.write(consts::TXT_UNDERL2_ON)?),
             "NORMAL" | _ => {
-                let _ = self.write(consts::TXT_BOLD_OFF);
-                let _ = self.write(consts::TXT_UNDERL_OFF);
+                Ok(self.write(consts::TXT_BOLD_OFF)? + self.write(consts::TXT_UNDERL_OFF)?)
             }
         }
-        self
     }
 
-    pub fn size(&mut self, width: usize, height: usize) -> &mut Printer<W> {
-        let _ = self.write(consts::TXT_NORMAL);
+    pub fn size(&mut self, width: usize, height: usize) -> io::Result<usize> {
+        let mut n = self.write(consts::TXT_NORMAL)?;
         if width == 2 {
-            let _ = self.write(consts::TXT_2WIDTH);
+            n += self.write(consts::TXT_2WIDTH)?;
         }
         if height == 2 {
-            let _ = self.write(consts::TXT_2HEIGHT);
+            n += self.write(consts::TXT_2HEIGHT)?;
         }
-        self
+        Ok(n)
     }
 
-    pub fn hardware(&mut self, hw: &str) -> &mut Printer<W> {
+    pub fn hardware(&mut self, hw: &str) -> io::Result<usize> {
         let value = match hw {
             "INIT" => consts::HW_INIT,
             "SELECT" => consts::HW_SELECT,
             "RESET" => consts::HW_RESET,
-            _ => panic!("Invalid hardware command: {}", hw)
+            _ => panic!("Invalid hardware command: {}", hw),
         };
-        let _ = self.write(value);
-        self
+        self.write(value)
     }
 
-    pub fn barcode(&mut self,
-                   code: &str,
-                   kind: &str,
-                   position: &str,
-                   font: &str,
-                   width: usize, height: usize) -> &mut Printer<W> {
+    pub fn barcode(
+        &mut self,
+        code: &str,
+        kind: &str,
+        position: &str,
+        font: &str,
+        width: usize,
+        height: usize,
+    ) -> io::Result<usize> {
+        let mut n = 0;
         if width >= 1 || width <= 255 {
-            let _ = self.write(consts::BARCODE_WIDTH);
+            n += self.write(consts::BARCODE_WIDTH)?;
         }
         if height >= 2 || height <= 6 {
-            let _ = self.write(consts::BARCODE_HEIGHT);
+            n += self.write(consts::BARCODE_HEIGHT)?;
         }
 
         let font = font.to_uppercase();
@@ -213,7 +182,7 @@ impl<W: io::Write> Printer<W> {
         let kind = kind.to_uppercase().replace("-", "_");
         let font_value = match font.as_ref() {
             "B" => consts::BARCODE_FONT_B,
-            "A" | _ => consts::BARCODE_FONT_A
+            "A" | _ => consts::BARCODE_FONT_A,
         };
         let txt_value = match position.as_ref() {
             "OFF" => consts::BARCODE_TXT_OFF,
@@ -222,32 +191,32 @@ impl<W: io::Write> Printer<W> {
             "BLW" | _ => consts::BARCODE_TXT_BLW,
         };
         let kind_value = match kind.as_ref() {
-            "UPC_A"  => consts::BARCODE_UPC_A,
-            "UPC_E"  => consts::BARCODE_UPC_E,
-            "EAN8"   => consts::BARCODE_EAN8,
+            "UPC_A" => consts::BARCODE_UPC_A,
+            "UPC_E" => consts::BARCODE_UPC_E,
+            "EAN8" => consts::BARCODE_EAN8,
             "CODE39" => consts::BARCODE_CODE39,
-            "ITF"    => consts::BARCODE_ITF,
-            "NW7"    => consts::BARCODE_NW7,
-            "EAN13" | _ => consts::BARCODE_EAN13
+            "ITF" => consts::BARCODE_ITF,
+            "NW7" => consts::BARCODE_NW7,
+            "EAN13" | _ => consts::BARCODE_EAN13,
         };
-        let _ = self.write(font_value);
-        let _ = self.write(txt_value);
-        let _ = self.write(kind_value);
-        let _ = self.write(code.as_bytes());
-        self
+        n += self.write(font_value)?;
+        self.write(txt_value)?;
+        self.write(kind_value)?;
+        self.write(code.as_bytes())?;
+        Ok(n)
     }
 
-    #[cfg(feature="qrcode")]
-    pub fn qrimage(&mut self) -> &mut Printer<W> {
-        self
-    }
+    #[cfg(feature = "qrcode")]
+    pub fn qrimage(&mut self) -> io::Result<usize> {}
 
-    #[cfg(feature="qrcode")]
-    pub fn qrcode(&mut self,
-                  code: &str,
-                  version: Option<i32>,
-                  level: &str,
-                  size: Option<i32>) -> &mut Printer<W> {
+    #[cfg(feature = "qrcode")]
+    pub fn qrcode(
+        &mut self,
+        code: &str,
+        version: Option<i32>,
+        level: &str,
+        size: Option<i32>,
+    ) -> io::Result<usize> {
         let level = level.to_uppercase();
         let level_value = match level.as_ref() {
             "M" => consts::QR_LEVEL_M,
@@ -255,63 +224,69 @@ impl<W: io::Write> Printer<W> {
             "H" => consts::QR_LEVEL_H,
             "L" | _ => consts::QR_LEVEL_L,
         };
-        let _ = self.write(consts::TYPE_QR);
-        let _ = self.write(consts::CODE2D);
-        let _ = self.write_u8(version.unwrap_or(3) as u8);
-        let _ = self.write(level_value);
-        let _ = self.write_u8(size.unwrap_or(3) as u8);
-        let _ = self.write_u16le(code.len() as u16);
-        let _ = self.write(code.as_bytes());
-        self
+        let mut n = 0;
+        n += self.write(consts::TYPE_QR)?;
+        n += self.write(consts::CODE2D)?;
+        n += self.write_u8(version.unwrap_or(3) as u8)?;
+        n += self.write(level_value)?;
+        n += self.write_u8(size.unwrap_or(3) as u8)?;
+        n += self.write_u16le(code.len() as u16)?;
+        n += self.write(code.as_bytes())?;
+        Ok(n)
     }
 
-    pub fn cashdraw(&mut self, pin: i32) -> &mut Printer<W> {
+    pub fn cashdraw(&mut self, pin: i32) -> io::Result<usize> {
         let pin_value = if pin == 5 {
             consts::CD_KICK_5
         } else {
             consts::CD_KICK_2
         };
-        let _ = self.write(pin_value);
-        self
+        self.write(pin_value)
     }
 
-    pub fn cut(&mut self, part: bool) -> &mut Printer<W> {
-        self.print(iter::repeat(consts::EOL)
-                   .take(3)
-                   .collect::<String>()
-                   .as_ref());
+    pub fn cut(&mut self, part: bool) -> io::Result<usize> {
+        let mut n_bytes = 0;
+        n_bytes += self.print(
+            iter::repeat(consts::EOL)
+                .take(3)
+                .collect::<String>()
+                .as_ref(),
+        )?;
         let paper_cut_type = if part {
             consts::PAPER_PART_CUT
         } else {
             consts::PAPER_FULL_CUT
         };
-        let _ = self.write(paper_cut_type);
-        self
+        n_bytes += self.write(paper_cut_type)?;
+        Ok(n_bytes)
     }
 
-    pub fn bit_image(&mut self,
-                    image: &Image,
-                    density: Option<&str>) -> &mut Printer<W> {
+    pub fn bit_image(&mut self, image: &Image, density: Option<&str>) -> io::Result<usize> {
         let density = density.unwrap_or("d24");
         let density_upper = density.to_uppercase();
         let header = match density_upper.as_ref() {
-            "S8"  => consts::BITMAP_S8,
-            "D8"  => consts::BITMAP_D8,
+            "S8" => consts::BITMAP_S8,
+            "D8" => consts::BITMAP_D8,
             "S24" => consts::BITMAP_S24,
             "D24" | _ => consts::BITMAP_D24,
         };
-        let n = if density == "s8" || density == "d8" { 1 } else { 3 };
-        self.line_space(0);
-        for line in image.bitimage_lines(n*8) {
-            let _ = self.write(header);
-            let _ = self.write_u16le((line.len() / n as usize) as u16);
-            let _ = self.write(line.as_ref());
-            self.feed(1);
+        let n = if density == "s8" || density == "d8" {
+            1
+        } else {
+            3
+        };
+        let mut n_bytes = 0;
+        n_bytes += self.line_space(0)?;
+        for line in image.bitimage_lines(n * 8) {
+            n_bytes += self.write(header)?;
+            n_bytes += self.write_u16le((line.len() / n as usize) as u16)?;
+            n_bytes += self.write(line.as_ref())?;
+            n_bytes += self.feed(1)?;
         }
-        self
+        Ok(n_bytes)
     }
 
-    pub fn raster(&mut self, image: &Image, mode: Option<&str>) -> &mut Printer<W> {
+    pub fn raster(&mut self, image: &Image, mode: Option<&str>) -> io::Result<usize> {
         let mode_upper = mode.unwrap_or("NORMAL").to_uppercase();
         let header = match mode_upper.as_ref() {
             "DH" => consts::GSV0_DH,
@@ -319,10 +294,11 @@ impl<W: io::Write> Printer<W> {
             "DW" => consts::GSV0_DW,
             "NORMAL" | _ => consts::GSV0_NORMAL,
         };
-        let _ = self.write(header);
-        let _ = self.write_u16le(((image.width+7)/8) as u16);
-        let _ = self.write_u16le(image.height as u16);
-        let _ = self.write(image.get_raster().as_ref());
-        self
+        let mut n_bytes = 0;
+        n_bytes += self.write(header)?;
+        n_bytes += self.write_u16le(((image.width+7)/8) as u16)?;
+        n_bytes += self.write_u16le(image.height as u16)?;
+        n_bytes += self.write(image.get_raster().as_ref())?;
+        Ok(n_bytes)
     }
 }

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -1,5 +1,4 @@
-use std::io;
-use std::io::Write;
+use std::io::{self, Write};
 use std::iter;
 
 use byteorder::{LittleEndian, WriteBytesExt};
@@ -98,7 +97,12 @@ impl<W: io::Write> Printer<W> {
             "CR" => consts::CTL_CR,
             "HT" => consts::CTL_HT,
             "VT" => consts::CTL_VT,
-            _ => panic!("Invalid control action: {}", ctrl),
+            _ => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("Invalid control action: {}", ctrl),
+                ))
+            }
         };
         self.write(ctrl_value)
     }
@@ -109,7 +113,12 @@ impl<W: io::Write> Printer<W> {
             "LT" => consts::TXT_ALIGN_LT,
             "CT" => consts::TXT_ALIGN_CT,
             "RT" => consts::TXT_ALIGN_RT,
-            _ => panic!("Invalid alignment: {}", alignment),
+            _ => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("Invalid alignment: {}", alignment),
+                ))
+            }
         };
         self.write(align_value)
     }
@@ -120,7 +129,12 @@ impl<W: io::Write> Printer<W> {
             "A" => consts::TXT_FONT_A,
             "B" => consts::TXT_FONT_B,
             "C" => consts::TXT_FONT_C,
-            _ => panic!("Invalid font family: {}", family),
+            _ => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("Invalid font family: {}", family),
+                ))
+            }
         };
         self.write(family_value)
     }
@@ -155,7 +169,12 @@ impl<W: io::Write> Printer<W> {
             "INIT" => consts::HW_INIT,
             "SELECT" => consts::HW_SELECT,
             "RESET" => consts::HW_RESET,
-            _ => panic!("Invalid hardware command: {}", hw),
+            _ => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("Invalid hardware command: {}", hw),
+                ))
+            }
         };
         self.write(value)
     }
@@ -296,7 +315,7 @@ impl<W: io::Write> Printer<W> {
         };
         let mut n_bytes = 0;
         n_bytes += self.write(header)?;
-        n_bytes += self.write_u16le(((image.width+7)/8) as u16)?;
+        n_bytes += self.write_u16le(((image.width + 7) / 8) as u16)?;
         n_bytes += self.write_u16le(image.height as u16)?;
         n_bytes += self.write(image.get_raster().as_ref())?;
         Ok(n_bytes)


### PR DESCRIPTION
Each call to the printer has the potential to fail due to IO errors. Instead of ignoring these, the method should return the result. If one method call results in several writes, the total of their written bytes is returned. 