### PR TITLE
docs: stdout example and docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "escposify"
-version = "0.5.2"
+version = "0.5.3"
 description = """
 A ESC/POS driver for Rust
 

--- a/examples/stdout.rs
+++ b/examples/stdout.rs
@@ -1,0 +1,14 @@
+use std::io::{self, stdout};
+
+use escposify::printer::Printer;
+
+fn main() -> io::Result<()> {
+    let mut printer = Printer::new(stdout(), None, None);
+
+    printer
+        .chain_feed(2)?
+        .chain_text("The quick brown fox jumps over the lazy dog")?
+        .chain_text("敏捷的棕色狐狸跳过懒狗")?
+        .chain_feed(1)?
+        .flush()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,29 @@
 //!         .flush()
 //! }
 //! ```
+//!
+//! ### Writing to the stdout
+//!
+//! Understandably not all options work here (alignment, fonts, chain_cut etc.)
+//! but for quick debugging and prototyping this is a good option
+//! as it saves tons of time when working on the logic of your implementation.
+//!
+//! ```rust
+//! use std::io::{self, stdout};
+//! use escposify::printer::Printer;
+//!
+//! fn main() -> io::Result<()> {
+//!
+//!     let mut printer = Printer::new(stdout(), None, None);
+//!
+//!     printer
+//!         .chain_feed(2)?
+//!         .chain_text("The quick brown fox jumps over the lazy dog")?
+//!         .chain_text("敏捷的棕色狐狸跳过懒狗")?
+//!         .chain_feed(1)?
+//!         .flush()
+//! }
+//! ```
 
 pub mod consts;
 pub mod device;


### PR DESCRIPTION
I've recently found out that I can write to the `io::stdout`  instead of to a physical device.
It saved me tons of time as I had very limited access to the hardware I was testing on. 

Maybe it is obvious for a seasoned Rust developer that it is possible to render in the terminal as the `Printer` struct implements `io::Write` but it certainly wasn't obvious for me 🙃 so I decided to create a PR to add that in the examples.