### PR TITLE
feat(usb): implement USB printing via vendor_id and product_id

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "escposify"
-version = "0.5.3"
+version = "0.6.3"
 description = """
 A ESC/POS driver for Rust
 
@@ -21,6 +21,7 @@ qrcode_builder = ["qrcode"]
 encoding = "0.2"
 byteorder = "1.4"
 image = "0.24"
+rusb = "0.9.3"
 
 qrcode =  { version = "0.12", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "escposify"
-version = "0.6.3"
+version = "0.6.0"
 description = """
 A ESC/POS driver for Rust
 

--- a/examples/usb.rs
+++ b/examples/usb.rs
@@ -1,0 +1,24 @@
+use std::io;
+
+use escposify::device::Usb;
+use escposify::printer::Printer;
+
+fn main() -> io::Result<()> {
+    let product_id = 0xa700; // find the correct product_id for your printer
+    let vendor_id = 0x0525; // find the correct vendor_id for your printer
+    let usb = Usb::new(vendor_id, product_id)?;
+
+    let mut printer = Printer::new(usb, None, None);
+
+    printer
+        .chain_feed(5)?
+        .chain_font("C")?
+        .chain_align("lt")?
+        .chain_style("bu")?
+        .chain_size(0, 0)?
+        .chain_text("The quick brown fox jumps over the lazy dog")?
+        .chain_barcode("12345678", "EAN8", "", "", 0, 0)?
+        .chain_feed(5)?
+        .chain_cut(false)?
+        .flush()
+}

--- a/src/device.rs
+++ b/src/device.rs
@@ -135,12 +135,9 @@ impl Usb {
                     Ok(mut dvc) => {
                         if let Ok(active) = dvc.kernel_driver_active(0) {
                             if active {
-                                match dvc.detach_kernel_driver(0) {
-                                    Ok(_) => (),
-                                    Err(e) => {
-                                        return Err(io::Error::new(io::ErrorKind::Other, e));
-                                    }
-                                };
+                                if let Err(e) = dvc.detach_kernel_driver(0) {
+                                    return Err(io::Error::new(io::ErrorKind::Other, e));
+                                }
                             }
                         } else {
                             return Err(io::Error::new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,34 @@
 //!         .flush()
 //! }
 //! ```
+//!
+//! ### Printing to a printer via USB
+//!
+//! ```rust
+//! use std::io;
+//! use escposify::printer::Printer;
+//! use escposify::device::Usb;
+//!
+//! fn main() -> io::Result<()> {
+//!     let product_id = 0xa700;
+//!     let vendor_id = 0x0525;
+//!     let usb = Usb::new(vendor_id, product_id)?;
+//!
+//!     let mut printer = Printer::new(usb, None, None);
+//!
+//!     printer
+//!         .chain_feed(5)?
+//!         .chain_font("C")?
+//!         .chain_align("lt")?
+//!         .chain_style("bu")?
+//!         .chain_size(0, 0)?
+//!         .chain_text("The quick brown fox jumps over the lazy dog")?
+//!         .chain_barcode("12345678", "EAN8", "", "", 0, 0)?
+//!         .chain_feed(5)?
+//!         .chain_cut(false)?
+//!         .flush()
+//! }
+//! ```
 
 pub mod consts;
 pub mod device;


### PR DESCRIPTION
# This PR

Adds support for USB printing via `vendor_id` and `product_id`

The implementation is heavily inspired by `escpos-rs` crate but tries to use a bit more idiomatic Rust.

*Please feel free to cancel the PR if this wasn't the intention of the `Usb` struct or for any other reason you think valid.*

#### How to use
```rust
    let product_id = 0xa700; // find the correct product_id for your printer
    let vendor_id = 0x0525; // find the correct vendor_id for your printer
    let usb = Usb::new(vendor_id, product_id)?;

    let mut printer = Printer::new(usb, None, None);

    printer
        .chain_feed(5)?
        .chain_font("C")?
        .chain_align("lt")?
        .chain_style("bu")?
        .chain_size(0, 0)?
        .chain_text("The quick brown fox jumps over the lazy dog")?
        .chain_barcode("12345678", "EAN8", "", "", 0, 0)?
        .chain_feed(5)?
        .chain_cut(false)?
        .flush()
```
![76E987B1-1379-4F20-A16F-66A4055C9E08](https://github.com/local-group/rust-escposify/assets/12900528/f66a7f94-c4ed-42e1-9f10-5bbeed2e7785)
